### PR TITLE
refactor: remove dead temperature/max_tokens parameter plumbing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+- **Dead sampling parameters**: Removed unused `temperature`/`max_tokens` plumbing through `BaseTextHandler`, all chat/messages/responses handlers, and `buildChatRequestBody` — the 1min.ai Chat with AI API has no sampling parameters, so these values were silently dropped. Request types still accept them for OpenAI/Anthropic SDK compatibility, now explicitly documented as not forwarded upstream. (`max_tokens` remains validated as required on `/v1/messages` per the Anthropic spec.)
+
 ## [5.0.1] - 2026-04-12
 
 ### Fixed

--- a/src/handlers/base.ts
+++ b/src/handlers/base.ts
@@ -23,16 +23,12 @@ export abstract class BaseTextHandler {
     messages: Message[],
     model: string,
     apiKey: string,
-    temperature?: number,
-    maxTokens?: number,
     webSearchConfig?: WebSearchConfig,
   ): Promise<OneMinChatResponse> {
     const requestBody = await this.apiService.buildChatRequestBody(
       messages,
       model,
       apiKey,
-      temperature,
-      maxTokens,
       webSearchConfig,
     );
 
@@ -52,16 +48,12 @@ export abstract class BaseTextHandler {
     messages: Message[],
     model: string,
     apiKey: string,
-    temperature?: number,
-    maxTokens?: number,
     webSearchConfig?: WebSearchConfig,
   ): Promise<Response> {
     const requestBody = await this.apiService.buildChatRequestBody(
       messages,
       model,
       apiKey,
-      temperature,
-      maxTokens,
       webSearchConfig,
     );
 

--- a/src/handlers/chat.ts
+++ b/src/handlers/chat.ts
@@ -50,8 +50,6 @@ export class ChatHandler extends BaseTextHandler {
         processedMessages,
         cleanModel,
         apiKey,
-        requestBody.temperature,
-        requestBody.max_tokens,
         webSearchConfig,
       );
     } else {
@@ -59,8 +57,6 @@ export class ChatHandler extends BaseTextHandler {
         processedMessages,
         cleanModel,
         apiKey,
-        requestBody.temperature,
-        requestBody.max_tokens,
         webSearchConfig,
       );
     }
@@ -70,16 +66,12 @@ export class ChatHandler extends BaseTextHandler {
     messages: Message[],
     model: string,
     apiKey: string,
-    temperature?: number,
-    maxTokens?: number,
     webSearchConfig?: WebSearchConfig,
   ): Promise<Response> {
     const data = await this.sendNonStreamingRequest(
       messages,
       model,
       apiKey,
-      temperature,
-      maxTokens,
       webSearchConfig,
     );
 
@@ -91,16 +83,12 @@ export class ChatHandler extends BaseTextHandler {
     messages: Message[],
     model: string,
     apiKey: string,
-    temperature?: number,
-    maxTokens?: number,
     webSearchConfig?: WebSearchConfig,
   ): Promise<Response> {
     const response = await this.sendStreamingRequest(
       messages,
       model,
       apiKey,
-      temperature,
-      maxTokens,
       webSearchConfig,
     );
 

--- a/src/handlers/messages.ts
+++ b/src/handlers/messages.ts
@@ -55,7 +55,6 @@ export class MessagesHandler extends BaseTextHandler {
       return this.handleStreamingMessage(
         processedMessages,
         cleanModel,
-        requestBody,
         apiKey,
         webSearchConfig,
       );
@@ -63,7 +62,6 @@ export class MessagesHandler extends BaseTextHandler {
       return this.handleNonStreamingMessage(
         processedMessages,
         cleanModel,
-        requestBody,
         apiKey,
         webSearchConfig,
       );
@@ -136,7 +134,6 @@ export class MessagesHandler extends BaseTextHandler {
   private async handleNonStreamingMessage(
     messages: Message[],
     model: string,
-    originalRequest: AnthropicMessageRequest,
     apiKey: string,
     webSearchConfig?: WebSearchConfig,
   ): Promise<Response> {
@@ -144,8 +141,6 @@ export class MessagesHandler extends BaseTextHandler {
       messages,
       model,
       apiKey,
-      originalRequest.temperature,
-      originalRequest.max_tokens,
       webSearchConfig,
     );
 
@@ -164,7 +159,6 @@ export class MessagesHandler extends BaseTextHandler {
   private async handleStreamingMessage(
     messages: Message[],
     model: string,
-    originalRequest: AnthropicMessageRequest,
     apiKey: string,
     webSearchConfig?: WebSearchConfig,
   ): Promise<Response> {
@@ -172,8 +166,6 @@ export class MessagesHandler extends BaseTextHandler {
       messages,
       model,
       apiKey,
-      originalRequest.temperature,
-      originalRequest.max_tokens,
       webSearchConfig,
     );
 

--- a/src/handlers/responses.ts
+++ b/src/handlers/responses.ts
@@ -70,8 +70,6 @@ export class ResponseHandler extends BaseTextHandler {
       return this.handleStreamingResponse(
         processedMessages,
         cleanModel,
-        requestBody.temperature,
-        requestBody.max_tokens,
         requestBody.response_format,
         requestBody.reasoning_effort,
         apiKey,
@@ -82,8 +80,6 @@ export class ResponseHandler extends BaseTextHandler {
     return this.handleNonStreamingResponse(
       processedMessages,
       cleanModel,
-      requestBody.temperature,
-      requestBody.max_tokens,
       requestBody.response_format,
       requestBody.reasoning_effort,
       apiKey,
@@ -129,8 +125,6 @@ export class ResponseHandler extends BaseTextHandler {
   private async handleNonStreamingResponse(
     messages: Message[],
     model: string,
-    temperature?: number,
-    maxTokens?: number,
     responseFormat?: ResponseFormat,
     reasoningEffort?: ResponseRequest["reasoning_effort"],
     apiKey?: string,
@@ -146,8 +140,6 @@ export class ResponseHandler extends BaseTextHandler {
       enhancedMessages,
       model,
       apiKey || "",
-      temperature,
-      maxTokens,
       webSearchConfig,
     );
 
@@ -162,8 +154,6 @@ export class ResponseHandler extends BaseTextHandler {
   private async handleStreamingResponse(
     messages: Message[],
     model: string,
-    temperature?: number,
-    maxTokens?: number,
     responseFormat?: ResponseFormat,
     reasoningEffort?: ResponseRequest["reasoning_effort"],
     apiKey?: string,
@@ -179,8 +169,6 @@ export class ResponseHandler extends BaseTextHandler {
       enhancedMessages,
       model,
       apiKey || "",
-      temperature,
-      maxTokens,
       webSearchConfig,
     );
 

--- a/src/services/onemin-api.ts
+++ b/src/services/onemin-api.ts
@@ -188,12 +188,12 @@ export class OneMinApiService {
     return data as OneMinImageResponse;
   }
 
+  // Note: the 1min.ai Chat with AI API has no sampling parameters
+  // (temperature/max_tokens) — see docs.1min.ai/docs/api/chat-with-ai-api.
   async buildChatRequestBody(
     messages: Message[],
     model: string,
     apiKey: string,
-    _temperature?: number,
-    _maxTokens?: number,
     webSearchConfig?: WebSearchConfig,
   ): Promise<OneMinRequestBody> {
     // Process images from the latest user message

--- a/src/types/anthropic.ts
+++ b/src/types/anthropic.ts
@@ -61,6 +61,9 @@ export interface AnthropicMessageRequest {
   model: string;
   messages: AnthropicMessage[];
   system?: string | AnthropicTextContent[];
+  // max_tokens is validated (required by the Anthropic spec) but, like the
+  // other sampling parameters, NOT forwarded upstream — the 1min.ai API has
+  // no sampling parameters.
   max_tokens: number;
   temperature?: number;
   top_p?: number;

--- a/src/types/requests.ts
+++ b/src/types/requests.ts
@@ -16,6 +16,8 @@ export interface ChatCompletionRequest {
           };
         }>;
   }>;
+  // Accepted for OpenAI SDK compatibility but NOT forwarded upstream:
+  // the 1min.ai Chat with AI API has no sampling parameters.
   temperature?: number;
   max_tokens?: number;
   stream?: boolean;
@@ -57,6 +59,8 @@ export interface ResponseRequest {
         }>;
   }>;
   instructions?: string;
+  // Accepted for SDK compatibility but NOT forwarded upstream (no sampling
+  // parameters in the 1min.ai API).
   temperature?: number;
   max_tokens?: number;
   stream?: boolean;


### PR DESCRIPTION
## Summary

- Remove the unused `temperature`/`max_tokens` parameter chain threaded through `BaseTextHandler`, the chat/messages/responses handlers, and `buildChatRequestBody` — the values were received as `_temperature`/`_maxTokens` and silently dropped
- Verified against [docs.1min.ai Chat with AI API](https://docs.1min.ai/docs/api/chat-with-ai-api): `promptObject.settings` only supports `webSearchSettings`, `historySettings`, and `withMemories` — there are no sampling parameters upstream, so wiring them up is not an option
- Request types still accept `temperature`/`max_tokens` for OpenAI/Anthropic SDK compatibility, now with explicit comments that they are **not forwarded upstream**
- `max_tokens` remains validated as required on `/v1/messages` per the Anthropic spec
- Add CHANGELOG entry under `[Unreleased]`

No observable API behavior change — these parameters were already ignored.

## Test plan

- [x] `tsc --noEmit` passes
- [x] `biome check src/` passes
- [ ] Manual smoke test via `npm run dev` (chat/messages/responses endpoints unchanged)